### PR TITLE
Make first description more focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 <img src="https://storeon.github.io/storeon/logo.svg" align="right"
      alt="Storeon logo by Anton Lovchikov" width="160" height="142">
 
-The 171 bytes module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
-It uses [Size Limit] to control the size.
+Tiny module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
+
+It is just 171 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon


### PR DESCRIPTION
What do you think if we will split the first description into “what it does” and “what is the size” paragraphs? It could make the first sentence more focused on what is important for users.