### PR TITLE
Save state to storage only on @changed event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.8.0
+
+Ignore storeon @changed events so that data is not stored twice.
+
 ## 0.7.0
 
 * Adding support for RegExp for using in `path` param. (by Andy Chen https://github.com/KsRyY)
@@ -35,7 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.4
 
 * Rewrite the module to use only ES5 syntax
-* Reduce the size 
+* Reduce the size
 * Add tests
 * Update documentation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
 
-It is just 202 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 218 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon

--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ var persistState = function (paths, config) {
         }
       } catch (err) { }
     })
-    store.on('@dispatch', function (state) {
-      if (!initialized) {
+    store.on('@dispatch', function (state, event) {
+      if (!initialized || event[0] !== '@changed') {
         return
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storeon/localstorage",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Module for storeon to persist data from state to local storage",
   "repository": "storeon/localstorage",
   "author": "Ivan Menshykov <ivan.menshykov@gmail.com>",
@@ -42,7 +42,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "202 B"
+      "limit": "218 B"
     }
   ],
   "eslintConfig": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,18 @@ it('should update the localStorage', () => {
   expect(localStorage.getItem('storeon')).toEqual(JSON.stringify({ b: 1 }))
 })
 
+it('should update the localStorage only once, on @changed events', () => {
+  let spy = jest.spyOn(JSON, 'stringify')
+
+  let store = createStore([persistState()])
+  store.on('test', () => {
+    return { b: 1 }
+  })
+  store.dispatch('test')
+
+  expect(spy).toHaveBeenCalledTimes(1)
+})
+
 it('should update the state after init', () => {
   let data = JSON.stringify({ a: 1, b: 2 })
   localStorage.setItem('storeon', data)


### PR DESCRIPTION
Doing `store.dispatch('fancy-event', data);` and doing some state update, actually triggers `@dispatch` twice.
One with event 'fancy-event', other with event `@changed`.

We can avoid duplicated save to localStorage by ignoring non-`@changed` events.

Test spies on `JSON.stringify` instead of `localStorage` because the later is kind of tricky to spy with jest.

**Bumped minor to 0.8.0**

**Raised size limit from 202B to 218B** 😐

Check https://github.com/storeon/storeon/issues/89