### PR TITLE
fix TS2714

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,7 @@ declare namespace StoreonLocalStorage {
  *    `localStorage`. Defaults value is `localStorage`.
  *     Defaults value is `localStorage`.
  */
-declare function persistState<State>(
+export declare function persistState<State>(
   paths?: string[]|RegExp[],
   config?: StoreonLocalStorage.Config
 ): StoreonModule<State>;
-
-export = { persistState };


### PR DESCRIPTION
TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.