### PR TITLE
Small changes and refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
 
-It is just 269 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 253 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "278 B"
+      "limit": "253 B"
     }
   ],
   "eslintConfig": {


### PR DESCRIPTION
* swapped all functions to arrow functions
* swapped "`@dispatch` with `event[0] !== '@changed'`" to just `@changed`
* moved state filtering to `filterState`
* did `try`\\`catch` around `JSON.*` methods only to prevent accidental catching of other errors
* doing `store.on('@changed', onChange)` in `@init` instead of `initialized` flag
* made event `data/update` into symbol because `data/update` seemed too generic and could overlap with other people modules
* for synchronous storages: return stored state directly from `@init` instead of going through event
* size is reduced a bit

travis will fail with coverage not being 100% due to #33
