### PR TITLE
Removed useless return in onChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
 
-It is just 253 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 251 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ let persistState = (paths, config) => {
     } catch (err) {
       return
     }
-    return storage.setItem(key, saveState)
+    storage.setItem(key, saveState)
   }
 
   let event = Symbol('persistState')

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "253 B"
+      "limit": "251 B"
     }
   ],
   "eslintConfig": {


### PR DESCRIPTION
A useless `return` sneaked into `onChange` handler in #34.

I removed it. Sorry.