### PR TITLE
Allow custom serialization/deserialization functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] to store and sync state to `localStorage`. It restores state from `localStorage` during page loading and saves state on every change.
 
-It is just 265 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 282 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon
@@ -93,6 +93,18 @@ type config.storage = Storage
 ```
 
 Set `config.storage` with `sessionStorage` or other `Storage` implementation to change storage target. Otherwise `localStorage` is used (default).
+
+```js
+type config.serializer = (object: any) => string
+```
+
+Set `config.serializer` to change serialization function. `JSON.stringify` is used by default.
+
+```js
+type config.deserializer = (data: string) => any
+```
+
+Set `config.deserializer` to change deserialization function. `JSON.parse` is used by default.
 
 ## LICENSE
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ declare namespace StoreonLocalStorage {
   export interface Config {
     key?: string;
     storage?: Storage;
+    serializer?: (object: any) => string;
+    deserializer?: (data: string) => any;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@
  *    to use in local storage
  * @param {Storage} [config.storage] Can be set as `sessionStorage` or
  *    `localStorage`. Defaults value is `localStorage`.
+ * @param {Function} [config.serializer] Function that will serialize
+ *    your data. Should take object as an argument. Defaults to `JSON.stringify`
+ * @param {Function} [config.deserializer] Function that will deserialize
+ *    your data. Should take string as an argument. Defaults to `JSON.parse`
  */
 let persistState = (paths, config) => {
   config = config || {}
@@ -17,6 +21,8 @@ let persistState = (paths, config) => {
 
   let key = config.key || 'storeon'
   let storage = config.storage || localStorage
+  let serializer = config.serializer || JSON.stringify
+  let deserializer = config.deserializer || JSON.parse
 
   let onChange = state => {
     if (paths.length) {
@@ -25,7 +31,7 @@ let persistState = (paths, config) => {
 
     let saveState
     try {
-      saveState = JSON.stringify(state)
+      saveState = serializer(state)
     } catch (err) {
       return
     }
@@ -36,7 +42,7 @@ let persistState = (paths, config) => {
   return store => {
     store.on(event, (_, serializedState) => {
       try {
-        return JSON.parse(serializedState)
+        return deserializer(serializedState)
       } catch (err) {}
     })
 
@@ -49,7 +55,7 @@ let persistState = (paths, config) => {
           savedState.then(value => store.dispatch(event, value))
         } else {
           try {
-            return JSON.parse(savedState)
+            return deserializer(savedState)
           } catch (err) {}
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "265 B"
+      "limit": "282 B"
     }
   ],
   "eslintConfig": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -193,3 +193,37 @@ it('should return nothing if there is no window', () => {
 
   expect(store.get()).toEqual({})
 })
+
+it('should take custom serializer function and call it', () => {
+  let serializer = jest.fn()
+
+  let store = createStoreon([
+    persistState(undefined, {
+      serializer
+    })
+  ])
+
+  store.on('test', () => {
+    return { a: 1 }
+  })
+  store.dispatch('test')
+
+  expect(serializer).toHaveBeenCalledWith(store.get())
+})
+
+it('should take custom deserializer function and call it', () => {
+  let deserializer = jest.fn()
+
+  let data = JSON.stringify({ a: 1, b: 2 })
+  localStorage.setItem('storeon', data)
+
+  let persistedState = localStorage.getItem('storeon')
+
+  createStoreon([
+    persistState(undefined, {
+      deserializer
+    })
+  ])
+
+  expect(deserializer).toHaveBeenCalledWith(persistedState)
+})


### PR DESCRIPTION
Changes:
- accept config properties `serializer` and `deserializer`
- use `JSON.stringify` as default serializer
- use `JSON.parse` as default deserializer

This changes allow using custom serializer/deserializer function for different purposes. E.g. you can use my package https://github.com/kamil7x/hydration-next to persist data with types. 

In my case it is used to store Date objects properly (deserializer automatically create Date objects from persisted data)